### PR TITLE
Remove unused `CODECOV_TOKEN` env var from GitHub CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,7 +19,6 @@ jobs:
         ruby-version: 2.6.x
     - name: Build and test with Rake
       env: # Or as an environment variable
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         CI: true
       run: |


### PR DESCRIPTION
I've been auditing our Codecov usages after their [Bash Uploader incident](https://about.codecov.io/security-update/).

I noticed this repo exports a `CODECOV_TOKEN` env var for the CI, but there's no usage of Codecov that I can find.

Assuming the tool is not used, this PR removes the token export.

---

Update: CI run fine, which I consider a proof that the token is unused.